### PR TITLE
Consolidate Dependabot updates into grouped weekly PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,43 @@
 version: 2
+
 updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 1
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
     assignees:
       - "wallstop"
     reviewers:
       - "wallstop"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "04:30"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 1
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
     assignees:
       - "wallstop"
     reviewers:


### PR DESCRIPTION
### Motivation
- Reduce Dependabot PR churn by preferring fewer, larger, area-grouped update PRs instead of many single-package PRs.
- Allow updates to accumulate so related version bumps can be merged together and reviewed as a unit.
- Keep existing review/ownership routing while improving maintainability of dependency upgrades.

### Description
- Updated `.github/dependabot.yml` to change both `pip` and `github-actions` ecosystems from a `daily` to a `weekly` schedule with explicit `day`, `time`, and `timezone` entries.
- Added `groups` for each ecosystem with a wildcard `patterns: ["*"]` and `update-types` including `major`, `minor`, and `patch` so Dependabot will bundle many updates into area-grouped PRs.
- Set `open-pull-requests-limit: 1` per ecosystem to encourage a single consolidated PR at a time.
- Preserved existing `assignees` and `reviewers` configuration and committed the change with the message "Consolidate Dependabot updates into grouped PRs".

### Testing
- Validated the YAML by running `python - <<'PY'` to `yaml.safe_load` the file and assert `version == 2` and that each `updates` entry contains `groups` with `patterns == ["*"]`, which succeeded.
- Programmatically updated and verified `open-pull-requests-limit` using a small Python script that wrote the file and printed confirmation, which succeeded.
- Inspected the file and the git diff (`cat .github/dependabot.yml` and `git diff`) and committed the change, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb042aa4308331b5b78bc7e37592d0)