### PR TITLE
refactor: Pythonic idioms in utils.py and encoding.py (regression-proof)

### DIFF
--- a/malbolge/encoding.py
+++ b/malbolge/encoding.py
@@ -22,6 +22,12 @@ class InvalidProgramError(ValueError):
     """Raised when a program cannot be normalized."""
 
 
+def _validate_program_length(instruction_list: list[str], *, extra_offset: int = 0) -> None:
+    """Raise InvalidProgramError if the program exceeds Malbolge's maximum length."""
+    if len(instruction_list) + extra_offset > MAX_PROGRAM_LENGTH:
+        raise InvalidProgramError("Program exceeds Malbolge maximum length (59049).")
+
+
 def normalize(instruction_list: Iterable[str]) -> list[str]:
     """
     Convert ASCII characters to Malbolge opcodes.
@@ -30,16 +36,13 @@ def normalize(instruction_list: Iterable[str]) -> list[str]:
     to remain compatible with legacy behaviour.
     """
     instruction_list = list(instruction_list)
-    if len(instruction_list) > MAX_PROGRAM_LENGTH:
-        raise InvalidProgramError("Program exceeds Malbolge maximum length (59049).")
+    _validate_program_length(instruction_list)
 
-    return_string = ""
-    for index, char in enumerate(instruction_list):
-        translated = NORMAL_TRANSLATE[((ord(char) + index - 33) % 94)]
-        if translated in VALID_INSTRUCTIONS:
-            return_string += translated
-
-    return list(return_string)
+    return [
+        NORMAL_TRANSLATE[(ord(char) + index - 33) % 94]
+        for index, char in enumerate(instruction_list)
+        if NORMAL_TRANSLATE[(ord(char) + index - 33) % 94] in VALID_INSTRUCTIONS
+    ]
 
 
 @functools.cache
@@ -54,16 +57,13 @@ def reverse_normalize(
 ) -> list[str]:
     """Encode Malbolge opcodes back into printable ASCII characters."""
     instruction_list = list(instruction_list)
-    total_length = start_index + len(instruction_list)
-    if total_length > MAX_PROGRAM_LENGTH:
-        raise InvalidProgramError("Program exceeds Malbolge maximum length (59049).")
+    _validate_program_length(instruction_list, extra_offset=start_index)
 
-    return_string = ""
-    for offset, char in enumerate(instruction_list):
+    for char in instruction_list:
         if char not in VALID_INSTRUCTIONS:
             raise InvalidProgramError("Invalid opcode encountered during decoding.")
-        index = start_index + offset
-        translated = chr(_opcode_offset(char, index) + 33)
-        return_string += translated
 
-    return list(return_string)
+    return [
+        chr(_opcode_offset(char, start_index + offset) + 33)
+        for offset, char in enumerate(instruction_list)
+    ]

--- a/malbolge/utils.py
+++ b/malbolge/utils.py
@@ -30,10 +30,7 @@ def convert_to_base3(value: int, digits: int = TERNARY_DIGITS) -> list[int]:
 
 def convert_to_base10(values: Sequence[int]) -> int:
     """Convert a sequence of ternary digits (LSB first) back to base 10."""
-    total = 0
-    for index, digit in enumerate(values):
-        total += digit * POWERS_OF_THREE[index]
-    return total
+    return sum(digit * POWERS_OF_THREE[index] for index, digit in enumerate(values))
 
 
 def ternary_rotate(value: int) -> int:
@@ -47,14 +44,10 @@ def crazy_operation(first: int, second: int) -> int:
     Execute the Malbolge 'crazy' operation on two values.
 
     The transformation is defined digit-wise using Malbolge's custom truth table.
+    Each ternary digit pair is looked up in the truth table and combined
+    with the corresponding power of three.
     """
-    total = 0
-    power = 1
-    local_first = first
-    local_second = second
-    for _ in range(TERNARY_DIGITS):
-        total += _CRAZY_TABLE[(local_first % 3) * 3 + (local_second % 3)] * power
-        local_first //= 3
-        local_second //= 3
-        power *= 3
-    return total
+    return sum(
+        _CRAZY_TABLE[((first // p) % 3) * 3 + ((second // p) % 3)] * p
+        for p in POWERS_OF_THREE
+    )


### PR DESCRIPTION
## Summary

Behavior-preserving refactoring of `utils.py` and `encoding.py`, verified safe by [Regrets](https://github.com/Wolfvin/Regrets) — an output-based regression testing framework.

### Changes

**`malbolge/utils.py`:**
- `convert_to_base10`: Replace explicit for-loop with `sum()` generator expression
- `crazy_operation`: Replace manual loop with `sum()` over `POWERS_OF_THREE`, using direct digit extraction `(first // p) % 3` instead of iterative division

**`malbolge/encoding.py`:**
- Extract `_validate_program_length()` helper to DRY up the `MAX_PROGRAM_LENGTH` validation shared by both `normalize()` and `reverse_normalize()`
- `normalize()`: Replace string concatenation loop with list comprehension
- `reverse_normalize()`: Separate input validation from transformation, replace string concatenation with list comprehension

### Regression Verification

All changes were verified using Regrets output-fingerprint regression testing:

| Verification | Method | Result |
|---|---|---|
| **VERIFICATION 1** — Regrets | All 6 fingerprint clusters validated (5-run drift detection) | ✅ All GREEN + STABLE |
| **VERIFICATION 2** — Direct output | Ran all entry functions, compared output vs pre-refactor ground truth | ✅ IDENTICAL |
| **VERIFICATION 3** — Cross-fingerprint | Computed fingerprints from new output vs pre-refactor fingerprints | ✅ MATCH |
| **Existing tests** | pytest full suite (53 tests) | ✅ All PASS |

#### Fingerprint Clusters (pre-refactor → post-refactor)

| Cluster | Function | Fingerprint | Status |
|---|---|---|---|
| convert-to-base3 | `convert_to_base3` | 3youxfq | ✅ MATCH |
| convert-to-base10 | `convert_to_base10` | 1233w7t | ✅ MATCH |
| ternary-rotate | `ternary_rotate` | 2iondrx | ✅ MATCH |
| crazy-operation | `crazy_operation` | 4v5ynxg | ✅ MATCH |
| normalize-encoding | `normalize` | 5cgrxcq | ✅ MATCH |
| reverse-normalize-encoding | `reverse_normalize` | 8ezmwg3 | ✅ MATCH |

### Key Insight: Bug Found in Regrets Itself

During testing, we discovered that the Python `validate.py` drift detection had a false-positive bug — it compared fingerprints across different inputs instead of per-input across runs. This bug was already fixed in the JS validator but not ported to Python. We submitted the fix as [Wolfvin/Regrets#50](https://github.com/Wolfvin/Regrets/pull/50).